### PR TITLE
Fix README bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **RSS Feed**  
   Automatic `/feed.xml` podcast feed (no iTunes-specific tags) sorted by original publish date.
 
-- **Firestore + FireStorage**  
+- **Firestore + Cloud Storage**  
   Metadata in Firestore (status, tags, voice choice, timestamps, IPs) + MP3s in a GCS bucket.
 
 ---


### PR DESCRIPTION
## Summary
- reference 'Cloud Storage' instead of 'FireStorage'

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_684b928ab25c8321a1c3b63d487302fa