### PR TITLE
Fix /submit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ DEFAULT_VOICE	Fallback voice if none is selected or invalid
 	•	GET /items/<id> → detail & player
 	•	GET /errors → list & retry failures
 	•	JSON API
-	•	POST /submit → { url, voice_name } → { item_id, tts_uri }
+	•	POST /submit → { url, voice_name } → { message, item_id } (confirmation, not tts_uri)
 	•	GET  /api/recent → latest 5 done items
 	•	GET  /api/items → paginated, filterable list
 	•	PUT  /api/items/<id>/tags → update tags


### PR DESCRIPTION
## Summary
- update endpoint reference for `/submit` to match `app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_684b9fe252948321af40062d6a105e9a