### PR TITLE
Fix DummyDocRef in tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,6 +31,8 @@ def use_test_client(monkeypatch, tmp_path):
         def __init__(self):
             # Give a constant dummy ID for testing
             self.id = "dummy-item-id"
+            # Mimic Firestore DocumentSnapshot.exists attribute
+            self.exists = False
 
         def set(self, data):
             return None
@@ -38,7 +40,10 @@ def use_test_client(monkeypatch, tmp_path):
         def update(self, data):
             return None
 
-        @property
+        def get(self):
+            """Return self to mimic Firestore's document reference .get()."""
+            return self
+
         def to_dict(self):
             return {}
 


### PR DESCRIPTION
## Summary
- adjust DummyDocRef in tests to better mimic Firestore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_684b9fda942483218947f4fb2f165953